### PR TITLE
fix compilation on pre-3.6 protobuf (a.k.a. Ubuntu 18.04)

### DIFF
--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -94,7 +94,11 @@ namespace comms_protobuf {
         template<typename Message>
         uint8_t* encodeFrame(uint8_t* buffer, uint8_t* buffer_end,
                              Message const& message) {
+#if GOOGLE_PROTOBUF_VERSION >= 3006001
             size_t payload_length = message.ByteSizeLong();
+#else
+            size_t payload_length = message.ByteSize();
+#endif
             auto message_end = buffer + validateEncodingBufferSize(
                 buffer_end - buffer, payload_length
             );

--- a/test/test_Channel.cpp
+++ b/test/test_Channel.cpp
@@ -21,9 +21,15 @@ struct ChannelTest : public ::testing::Test, iodrivers_base::Fixture<TestChannel
         vector<uint8_t> marshalled(256);
         msg.SerializeToArray(&marshalled[0], marshalled.size());
 
+#if GOOGLE_PROTOBUF_VERSION >= 3006001
+        size_t message_size = msg.ByteSizeLong();
+#else
+        size_t message_size = msg.ByteSize();
+#endif
+
         uint8_t buffer[1024];
         uint8_t* end = protocol::encodeFrame(
-            buffer, buffer + 1024, &marshalled[0], &marshalled[0] + msg.ByteSizeLong()
+            buffer, buffer + 1024, &marshalled[0], &marshalled[0] + message_size
         );
         this->pushDataToDriver(buffer, end);
     }


### PR DESCRIPTION
To be honest, I don't know what exact version started supporting ByteSizeLong, only
that 3.6 (19.04) does and 3.0 (18.04) does not