### PR TITLE
implement optional encryption

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 rock_library(comms_protobuf
     SOURCES Protocol.cpp
     HEADERS Protocol.hpp Channel.hpp
-    DEPS_PKGCONFIG iodrivers_base)
+    DEPS_PKGCONFIG iodrivers_base libcrypto)
 

--- a/src/Channel.hpp
+++ b/src/Channel.hpp
@@ -26,13 +26,22 @@ namespace comms_protobuf {
         typedef Channel<Local, Remote> ChannelType;
 
     private:
-        /** Send buffer used internally
-         */
-        std::vector<uint8_t> m_send_buffer;
+        protocol::CipherContext* m_cipher = nullptr;
+        bool m_encrypted = false;
 
-        /** Receive buffer used internally
+        /** Send/receive buffer used internally
          */
-        std::vector<uint8_t> m_receive_buffer;
+        std::vector<uint8_t> m_io_buffer;
+
+        /** Buffer used as target when decrypting the payload from m_io_buffer
+         */
+        std::vector<uint8_t> m_plaintext_buffer;
+
+        /**
+         * Buffer used as target when encrypting the serialized version of the
+         * protobuf message
+         */
+        std::vector<uint8_t> m_ciphertext_buffer;
 
         int extractPacket(uint8_t const* buffer, size_t size) const {
             return protocol::extractPacket(buffer, size, m_max_message_size);
@@ -53,8 +62,25 @@ namespace comms_protobuf {
         Channel(size_t max_message_size)
             : iodrivers_base::Driver(getBufferSizeFromMessageSize(max_message_size))
             , m_max_message_size(max_message_size)
-            , m_send_buffer(getBufferSizeFromMessageSize(max_message_size))
-            , m_receive_buffer(getBufferSizeFromMessageSize(max_message_size)) {
+            , m_io_buffer(getBufferSizeFromMessageSize(max_message_size)) {
+        }
+
+        ~Channel() {
+            delete m_cipher;
+        }
+
+        void setEncryptionKey(std::string key) {
+            delete m_cipher;
+            m_cipher = new protocol::CipherContext(key);
+            m_encrypted = true;
+
+            size_t encryptedPayloadSize =
+                protocol::CipherContext::getMaxCiphertextLength(m_max_message_size);
+
+            m_io_buffer.resize(getBufferSizeFromMessageSize(encryptedPayloadSize));
+            m_plaintext_buffer.resize(
+                getBufferSizeFromMessageSize(m_max_message_size)
+            );
         }
 
         Remote read() {
@@ -66,12 +92,27 @@ namespace comms_protobuf {
         }
 
         Remote read(base::Time const& timeout, base::Time const& first_byte_timeout) {
-            size_t size = readPacket(&m_receive_buffer[0], m_receive_buffer.size(),
-                                        timeout, first_byte_timeout);
+            size_t size = readPacket(&m_io_buffer[0], m_io_buffer.size(),
+                                     timeout, first_byte_timeout);
             auto payload_range = protocol::getPayload(
-                &m_receive_buffer[0],
-                &m_receive_buffer[0] + size
+                &m_io_buffer[0],
+                &m_io_buffer[0] + size
             );
+
+            if (m_encrypted) {
+                // Payload starts with the AES tag
+                protocol::aes_tag tag;
+                uint8_t const* ciphertext_start = payload_range.first + tag.size();
+                std::copy(payload_range.first, ciphertext_start, tag.begin());
+
+                size_t ciphertext_length = payload_range.second - ciphertext_start;
+                size_t size = protocol::decrypt(
+                    *m_cipher, &m_plaintext_buffer[0],
+                    payload_range.first + tag.size(), ciphertext_length, tag
+                );
+                payload_range.first = &m_plaintext_buffer[0];
+                payload_range.second = &m_plaintext_buffer[size];
+            }
 
             Remote result;
             bool success = result.ParseFromString(
@@ -88,9 +129,35 @@ namespace comms_protobuf {
         }
 
         void write(Local const& message) {
-            uint8_t* end = protocol::encodeFrame(
-                &m_send_buffer[0], &m_send_buffer[0] + m_send_buffer.size(), message);
-            writePacket(&m_send_buffer[0], end - &m_send_buffer[0]);
+            uint8_t* end;
+            if (m_encrypted) {
+#if GOOGLE_PROTOBUF_VERSION >= 3006001
+                size_t serialized_length = message.ByteSizeLong();
+#else
+                size_t serialized_length = message.ByteSize();
+#endif
+                message.SerializeWithCachedSizesToArray(&m_plaintext_buffer[0]);
+
+                protocol::aes_tag tag;
+                size_t ciphertext_length = protocol::encrypt(
+                    *m_cipher, &m_ciphertext_buffer[0], tag,
+                    &m_plaintext_buffer[0], serialized_length
+                );
+
+                end = protocol::encodeFrame(
+                    m_io_buffer.data(),
+                    m_io_buffer.data() + m_io_buffer.size(),
+                    m_ciphertext_buffer.data(),
+                    m_ciphertext_buffer.data() + ciphertext_length
+                );
+            }
+            else {
+                end = protocol::encodeFrame(
+                    &m_io_buffer[0], &m_io_buffer[0] + m_io_buffer.size(),
+                    message
+                );
+            }
+            writePacket(&m_io_buffer[0], end - &m_io_buffer[0]);
         }
     };
 }

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -87,6 +87,30 @@ namespace comms_protobuf {
          */
         uint16_t crc(uint8_t const* begin, uint8_t const* end);
 
+        typedef std::array<uint8_t, 16> aes_tag;
+
+        struct CipherContext {
+            static const int KEY_SIZE = 32;
+            static const int MAX_BLOCK_LENGTH = 32;
+
+            uint8_t key[KEY_SIZE];
+            uint8_t iv[KEY_SIZE];
+
+            CipherContext(std::string const& psk);
+
+            static constexpr int getMaxCiphertextLength(size_t size) {
+                return size + MAX_BLOCK_LENGTH - 1;
+            }
+        };
+
+        size_t encrypt(CipherContext& ctx,
+                       uint8_t* ciphertext, aes_tag& tag,
+                       uint8_t const* plaintext, size_t plaintext_length);
+        size_t decrypt(CipherContext& ctx,
+                       uint8_t* plaintext,
+                       uint8_t const* ciphertext, size_t ciphertext_length,
+                       aes_tag& tag);
+
         /** Encode a frame containing the given protobuf message
          *
          * @return the past-the-end pointer after the encoded frame

--- a/test/test_Channel.cpp
+++ b/test/test_Channel.cpp
@@ -68,3 +68,28 @@ TEST_F(ChannelTest, it_throws_if_receiving_a_message_that_is_valid_for_extractPa
 
     ASSERT_THROW(driver.read(), InvalidProtobufMessage);
 }
+
+struct SymmetricChannel : public Channel<test_channel::Local, test_channel::Local> {
+    typedef test_channel::Local Local;
+
+    SymmetricChannel()
+        : Channel<Local, Local>(100) {
+    }
+};
+
+struct EncryptedChannelTest :
+    public ::testing::Test, iodrivers_base::Fixture<SymmetricChannel> {
+};
+
+TEST_F(EncryptedChannelTest, it_can_handle_encrypted_communication) {
+    driver.openURI("test://");
+
+    test_channel::Local local;
+    local.set_something(10);
+    driver.write(local);
+
+    auto buffer = readDataFromDriver();
+    this->pushDataToDriver(buffer);
+    auto decrypted = driver.read();
+    ASSERT_EQ(10, decrypted.something());
+}


### PR DESCRIPTION
"embedded" channels such as LoRA or ZigBee do not always have encryption,
or encryption with weak authentication. Implement OpenSSL's recommended
cipher for encryption + authentication of the message (AES-GCM 256),
using a pre-shared key.

Depends on:
- [ ] https://github.com/tidewise/tidewise.common-package_set/pull/26