### PR TITLE
fix encryption handling in Channel

### DIFF
--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -99,7 +99,7 @@ namespace comms_protobuf {
             CipherContext(std::string const& psk);
 
             static constexpr int getMaxCiphertextLength(size_t size) {
-                return size + MAX_BLOCK_LENGTH - 1;
+                return size + MAX_BLOCK_LENGTH - 1 + sizeof(aes_tag);
             }
         };
 

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -5,6 +5,13 @@
 #include <array>
 
 namespace comms_protobuf {
+    struct DecryptionFailed : std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+    struct EncryptionFailed : std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+
     /** Implementation of the framing protocol
      */
     namespace protocol {

--- a/test/test_Channel.cpp
+++ b/test/test_Channel.cpp
@@ -82,6 +82,7 @@ struct EncryptedChannelTest :
 };
 
 TEST_F(EncryptedChannelTest, it_can_handle_encrypted_communication) {
+    driver.setEncryptionKey("test");
     driver.openURI("test://");
 
     test_channel::Local local;
@@ -92,4 +93,19 @@ TEST_F(EncryptedChannelTest, it_can_handle_encrypted_communication) {
     this->pushDataToDriver(buffer);
     auto decrypted = driver.read();
     ASSERT_EQ(10, decrypted.something());
+}
+
+TEST_F(EncryptedChannelTest, it_rejects_a_communication_with_the_wrong_key) {
+    driver.setEncryptionKey("test");
+    driver.openURI("test://");
+
+    test_channel::Local local;
+    local.set_something(10);
+    driver.write(local);
+
+    auto buffer = readDataFromDriver();
+
+    driver.setEncryptionKey("other");
+    this->pushDataToDriver(buffer);
+    ASSERT_THROW(driver.read(), std::runtime_error);
 }

--- a/test/test_Channel.cpp
+++ b/test/test_Channel.cpp
@@ -107,5 +107,5 @@ TEST_F(EncryptedChannelTest, it_rejects_a_communication_with_the_wrong_key) {
 
     driver.setEncryptionKey("other");
     this->pushDataToDriver(buffer);
-    ASSERT_THROW(driver.read(), std::runtime_error);
+    ASSERT_THROW(driver.read(), DecryptionFailed);
 }

--- a/test/test_Protocol.cpp
+++ b/test/test_Protocol.cpp
@@ -248,7 +248,7 @@ TEST_F(ProtocolTest, it_detects_modifications_to_the_tag) {
     uint8_t final[10];
     ASSERT_THROW(
         (protocol::decrypt(ctx, final, encrypted, encrypted_size, tag)),
-        std::runtime_error
+        DecryptionFailed
     );
 }
 
@@ -267,6 +267,6 @@ TEST_F(ProtocolTest, it_detects_modifications_to_the_encrypted_data) {
     uint8_t final[10];
     ASSERT_THROW(
         (protocol::decrypt(ctx, final, encrypted, encrypted_size, tag)),
-        std::runtime_error
+        DecryptionFailed
     );
 }


### PR DESCRIPTION
Turns out that the encryption/decryption implementation in Protocol
was thoroughly tested, but the usage of it in Channel was not tested
at all.

Test, and fix.